### PR TITLE
Nuevo enlace: Desarrollo de Video Juegos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,75 +2,6 @@
 
 [![Join the chat at https://gitter.im/OpenVE/comunidades-en-telegram](https://badges.gitter.im/OpenVE/comunidades-en-telegram.svg)](https://gitter.im/OpenVE/comunidades-en-telegram?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-<<<<<<< HEAD
-| Comunidad                                | Administrador                            | Link                                     |
-| ---------------------------------------- | ---------------------------------------- | ---------------------------------------- |
-| Android                                  | ...                                      | https://telegram.me/AndroidDevVzla       |
-| Android (Soporte Técnico)                | @cyberthrone                             | https://telegram.me/joinchat/B5A3bAaZNO-_0HkAavsO1w |
-| Angular                                  | @abr4xas - @Villanuevand - @jmespiz - @jobsamuel - @skatox | https://telegram.me/ngvenezuela          |
-| ArchLinux y Derivados                    | @goidor                                  | https://telegram.me/archlinuxVE          |
-| Bases de Datos                           | @jelitox                                 | https://telegram.me/bdvzla               |
-| Bash/Zsh.Ve                              | @Tur3c0                                  | https://telegram.me/BashVe               |
-| Bitcoin                                  | @ajsb85                                  | https://telegram.me/btcven               |
-| C++                                      | @Kalpar501                               | https://telegram.me/joinchat/BrCK8gmzgY_A2-Z2qg_MRg |
-| Conocimiento Libre                       | @Seraph1                                 | https://telegram.me/joinchat/B9JUAATRuqeYAxaGYLq-ng |
-| CSL_VE                                   | @phenobarbital                           | https://telegram.me/joinchat/CIpccAYQwKfi_kktTuKisw |
-| Data Science Venezuela                   | @map0logo                                | https://telegram.me/DataScienceVE        |
-| Datos Abiertos y scraping                | @seraph1                                 | https://telegram.me/joinchat/B9JUAAaks9m5-2TefJsAuw |
-| Desarrollo VideoJuegos                   | @alexr1712                               | https://telegram.me/joinchat/B_QIWkDGwHp87P8N02KxlA |
-| Django                                   | @ebar0n                                  | https://telegram.me/joinchat/BJxZXQGEslbc0kdty8hRbQ |
-| Docker                                   | @Seraph1                                 | https://telegram.me/joinchat/B9JUAD5FWUGUQveQWCPZ6w |
-| Electrónica                              | @oteroweb                                | https://telegram.me/ElectroVe            |
-| Elixir                                   | @gusga - @highercomve                    | https://telegram.me/ElixirVe             |
-| FreeCodeCamp Barquisimeto                | @mirabalj                                | https://telegram.me/joinchat/AFn8xT7vPnlQbJc9mScY_A |
-| Freelancers Venezuela                    | @alexr1712 @oteroweb                     | https://telegram.me/freelancersve        |
-| Git                                      | @johannnn @Tur3c0                        | https://telegram.me/git_ve               |
-| Go                                       | @aasanchez                               | https://telegram.me/golangve             |
-| Front-End HTML-CSS.ve                    | @Tur3c0                                  | https://telegram.me/HTML_CSS_Ve          |
-| iOS                                      | @ajmarquez                               | https://telegram.me/joinchat/AH2ZUgIUXVcougUIOTurtg |
-| IoT, SoC, Arduino, Raspberry Pi, Orange Pi | @mirabalj                                | http://bit.ly/iot_latam                  |
-| Interaction Design                       | @m0000g                                  | https://telegram.me/interactiondesgin_spanish |
-| Intercambio Idiomas                      | @oteroweb                                | https://telegram.me/joinchat/BSBThz9-rGFHFQqukOoGww |
-| JavaScript Venezuela                     | @ajsb85                                  | https://telegram.me/vzlajs               |
-| Joomla                                   | @oteroweb                                | https://telegram.me/joinchat/BSBThwEBgP3723Tmij0lnw |
-| Juegos                                   | @edgardoweb                              | https://telegram.me/joinchat/AGqisAA-jlmIAAihME16vg |
-| Laravel Venezuela                        | @racosta26, @oteroweb                    | https://telegram.me/laravelVe            |
-| LibreOffice Venezuela                    | @Tur3c0 @Cyberthrone @Naudy              | https://telegram.me/LibreOfficeVe        |
-| Libros Técnicos                          | @willicab                                | https://telegram.me/LibrosTecnicos       |
-| Libros (PacktPub)                        | @guerrerocarlos                          | https://telegram.me/packtpubfreelearning |
-| Linux Venezuela                          | @andres_code                             | https://telegram.me/linux_ve             |
-| Matemáticas                              | @KDels                                   | https://telegram.me/canalMatematicas     |
-| Mobile Híbrido                           | ...                                      | https://telegram.me/mobilehybridappsve   |
-| MongoDB Venezuela                        | @ch1nux                                  | https://telegram.me/joinchat/02fb5338009af29975c7d694d2aec965 |
-| Mozilla                                  | @ajsb85                                  | https://telegram.me/mozilla_venezuela    |
-| Nginx Venezuela                          | @alexr1712                               | https://telegram.me/nginxvzla            |
-| Odoo Venezuela Devs                      | @fr33co                                  | https://telegram.me/OdooVeDevs           |
-| Ofertas de Empleo                        | @raiiac                                  | https://telegram.me/trabajovenezuela     |
-| Pentaho                                  | @hellfish2 - @Tur3c0                     | https://telegram.me/pentahoVE            |
-| PHP Venezuela                            | @Tur3c0 @aasanchez @joseayram @oyepez    | https://telegram.me/PHP_Ve               |
-| Plone Venezuela                          | @macagua                                 | https://telegram.me/PloneVe              |
-| Programadores Venezuela                  | @DitoScripts                             | https://telegram.me/ProgramadoresVenezuela |
-| Python Venezuela                         | @nhomar - @macagua                       | https://telegram.me/python_venezuela     |
-| RadioGNU                                 | ...                                      | https://telegram.me/radiognu             |
-| Radiotransmisores                        | @Carlosjq10                              | https://telegram.me/joinchat/EcfNBkAiETMBh62FdGrxRw |
-| Redes de datos y servidores              | @jotagarbar                              | https://telegram.me/joinchat/B4dJbwa1g_BBBGcEQNxDMw |
-| Ruby                                     | @andres_code - @highercomve - @hipsss    | https://telegram.me/ruby_ve              |
-| SEO                                      | @oteroweb                                | https://telegram.me/joinchat/BSBThwXSgx0-XiGZL6P6fQ |
-| ST.ve                                    | @Tur3c0                                  | https://telegram.me/st3_ve               |
-| Symfony                                  |                                          | https://telegram.me/symfonyVe            |
-| SysAdminVE                               | @arawako                                 | https://telegram.me/SysAdminVE           |
-| Tabletas Canaima                         | @edgardoweb                              | https://telegram.me/joinchat/AGqisAI0UHkuBQDbuWm34g |
-| Telegram Venezuela                       | @tomivs @vicxyz                          | http://telegram.me/VenezuelaTG           |
-| Ubuntu                                   | @C3s4r                                   | https://telegram.me/ubuntuve             |
-| VIM Venezuela                            | @gusga                                   | https://telegram.me/vimvnzla             |
-| Vue.js                                   | @raiiac @Tur3c0                          | https://telegram.me/vueVe                |
-| Wagtail CMS                              | @fr33co                                  | https://telegram.me/joinchat/AFVMlQTWq-3CcTsvGDhO-g |
-| Wikimedia Venezuela                      | @KDels                                   | https://telegram.me/grupowmve            |
-| Women in Tech                            | @m0000g - @tatadbb                       | https://telegram.me/womenintech_spanish  |
-| Wordpress Venezuela                      | @Richzendy - @skatox - @ThePhoenixBird   | https://telegram.me/WordPressVE          |
-| Yii Venezuela                            | @oteroweb  - @skatox - @raiiac           | https://telegram.me/YiiVzla              |
-| XANADU GNU/linux                         | @sinfallas                               | https://telegram.me/xanadulinux          |
-=======
 | Comunidad              | Administrador      | Link                                                          |
 |------------------------|--------------------|---------------------------------------------------------------|
 | Android                | ...                | https://telegram.me/AndroidDevVzla                            |
@@ -85,7 +16,7 @@
 | CSL_VE                 | @phenobarbital     | https://telegram.me/joinchat/CIpccAYQwKfi_kktTuKisw           |
 | Data Science Venezuela | @map0logo          | https://telegram.me/DataScienceVE                             |
 | Datos Abiertos y scraping | @seraph1        | https://telegram.me/joinchat/B9JUAAaks9m5-2TefJsAuw           |
-| Desarrollo VideoJuegos | @alexr1712         | https://telegram.me/joinchat/B_QIWkDGwHrqvgaALG5lNw           |
+| Desarrollo VideoJuegos | @alexr1712         | https://telegram.me/joinchat/B_QIWkDGwHp87P8N02KxlA           |
 | Django                 | @ebar0n            | https://telegram.me/joinchat/BJxZXQGEslbc0kdty8hRbQ           |
 | Docker                 | @Seraph1           | https://telegram.me/joinchat/B9JUAD5FWUGUQveQWCPZ6w           |
 | Electrónica            | @oteroweb          | https://telegram.me/ElectroVe                                 |
@@ -140,7 +71,6 @@
 | Wordpress Venezuela    | @Richzendy - @skatox - @ThePhoenixBird | https://telegram.me/WordPressVE           |
 | Yii Venezuela          | @oteroweb  - @skatox - @raiiac | https://telegram.me/YiiVzla                       |
 | XANADU GNU/linux       | @sinfallas         | https://telegram.me/xanadulinux                               |
->>>>>>> upstream/master
 
 
 ## Licencia

--- a/README.md
+++ b/README.md
@@ -2,73 +2,73 @@
 
 [![Join the chat at https://gitter.im/OpenVE/comunidades-en-telegram](https://badges.gitter.im/OpenVE/comunidades-en-telegram.svg)](https://gitter.im/OpenVE/comunidades-en-telegram?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-| Comunidad              | Administrador      | Link                                                          |
-|------------------------|--------------------|---------------------------------------------------------------|
-| Android                | ...                | https://telegram.me/AndroidDevVzla                            |
-| Android (Soporte Técnico) | @cyberthrone    | https://telegram.me/joinchat/B5A3bAaZNO-_0HkAavsO1w           |
-| Angular                | @abr4xas - @Villanuevand - @jmespiz - @jobsamuel - @skatox | https://telegram.me/ngvenezuela |
-| ArchLinux y Derivados  | @goidor            | https://telegram.me/archlinuxVE                               |
-| Bases de Datos         | @jelitox           | https://telegram.me/bdvzla                                    |
-| Bash/Zsh.Ve            | @Tur3c0            | https://telegram.me/BashVe                                    |
-| Bitcoin                | @ajsb85            | https://telegram.me/btcven                                    |
-| C++                    | @Kalpar501         | https://telegram.me/joinchat/BrCK8gmzgY_A2-Z2qg_MRg           |
-| Conocimiento Libre     | @Seraph1           | https://telegram.me/joinchat/B9JUAATRuqeYAxaGYLq-ng           |
-| CSL_VE                 | @phenobarbital     | https://telegram.me/joinchat/CIpccAYQwKfi_kktTuKisw           |
-| Data Science Venezuela | @map0logo          | https://telegram.me/DataScienceVE                             |
-| Datos Abiertos y scraping | @seraph1        | https://telegram.me/joinchat/B9JUAAaks9m5-2TefJsAuw           |
-| Desarrollo VideoJuegos | @alexr1712         | https://telegram.me/joinchat/B_QIWkDGwHrqvgaALG5lNw           |
-| Django                 | @ebar0n            | https://telegram.me/joinchat/BJxZXQGEslbc0kdty8hRbQ           |
-| Docker                 | @Seraph1           | https://telegram.me/joinchat/B9JUAD5FWUGUQveQWCPZ6w           |
-| Electrónica            | @oteroweb          | https://telegram.me/ElectroVe                                 |
-| Elixir                 | @gusga - @highercomve | https://telegram.me/ElixirVe                               |
-| FreeCodeCamp Barquisimeto    | @mirabalj | https://telegram.me/joinchat/AFn8xT7vPnlQbJc9mScY_A              |
-| Freelancers Venezuela  | @alexr1712 @oteroweb | https://telegram.me/freelancersve                           |
-| Git                    | @johannnn @Tur3c0  | https://telegram.me/git_ve                                    |
-| Go                     | @aasanchez         | https://telegram.me/golangve                                  |
-| Front-End HTML-CSS.ve  | @Tur3c0            | https://telegram.me/HTML_CSS_Ve                               |
-| iOS                    | @ajmarquez         | https://telegram.me/joinchat/AH2ZUgIUXVcougUIOTurtg           |
-| IoT, SoC, Arduino, Raspberry Pi, Orange Pi  | @mirabalj                           | http://bit.ly/iot_latam |
-| Interaction Design     | @m0000g            | https://telegram.me/interactiondesgin_spanish                 |
-| Intercambio Idiomas    | @oteroweb          | https://telegram.me/joinchat/BSBThz9-rGFHFQqukOoGww           |
-| JavaScript Venezuela   | @ajsb85            | https://telegram.me/vzlajs                                    |
-| Joomla                 | @oteroweb          | https://telegram.me/joinchat/BSBThwEBgP3723Tmij0lnw           |
-| Juegos                 | @edgardoweb        | https://telegram.me/joinchat/AGqisAA-jlmIAAihME16vg           |
-| Laravel Venezuela      | @racosta26, @oteroweb | https://telegram.me/laravelVe                              |
-| LibreOffice Venezuela  | @Tur3c0 @Cyberthrone @Naudy | https://telegram.me/LibreOfficeVe                    |
-| Libros Técnicos        | @willicab          | https://telegram.me/LibrosTecnicos                            |
-| Libros (PacktPub)      | @guerrerocarlos            | https://telegram.me/packtpubfreelearning              |
-| Linux Venezuela        | @andres_code       | https://telegram.me/linux_ve                                  |
-| Matemáticas            | @KDels             | https://telegram.me/canalMatematicas                          |
-| Mobile Híbrido         | ...                | https://telegram.me/mobilehybridappsve                        |
-| MongoDB Venezuela      | @ch1nux            | https://telegram.me/joinchat/02fb5338009af29975c7d694d2aec965 |
-| Mozilla                | @ajsb85            | https://telegram.me/mozilla_venezuela                         |
-| Nginx Venezuela        | @alexr1712         | https://telegram.me/nginxvzla                                 |
-| Odoo Venezuela Devs    | @fr33co            | https://telegram.me/OdooVeDevs                                |
-| Ofertas de Empleo      | @raiiac            | https://telegram.me/trabajovenezuela                          |
-| Pentaho                | @hellfish2 - @Tur3c0 | https://telegram.me/pentahoVE                               |
-| PHP Venezuela          | @Tur3c0 @aasanchez @joseayram @oyepez | https://telegram.me/PHP_Ve                 |
-| Plone Venezuela        | @macagua           | https://telegram.me/PloneVe                                   |
-| Programadores Venezuela| @DitoScripts       | https://telegram.me/ProgramadoresVenezuela                    |
-| Python Venezuela       | @nhomar - @macagua | https://telegram.me/python_venezuela                          |
-| RadioGNU               | ...                | https://telegram.me/radiognu                                  |
-| Radiotransmisores      | @Carlosjq10        | https://telegram.me/joinchat/EcfNBkAiETMBh62FdGrxRw           |
-| Redes de datos y servidores | @jotagarbar   | https://telegram.me/joinchat/B4dJbwa1g_BBBGcEQNxDMw           |
-| Ruby                   | @andres_code - @highercomve - @hipsss | https://telegram.me/ruby_ve                |
-| SEO                    | @oteroweb          | https://telegram.me/joinchat/BSBThwXSgx0-XiGZL6P6fQ           |
-| ST.ve                  | @Tur3c0            | https://telegram.me/st3_ve                                    |
-| Symfony                |                    | https://telegram.me/symfonyVe                                 |
-| SysAdminVE             | @arawako           | https://telegram.me/SysAdminVE                                |
-| Tabletas Canaima       | @edgardoweb        | https://telegram.me/joinchat/AGqisAI0UHkuBQDbuWm34g           |
-| Telegram Venezuela     | @tomivs @vicxyz    | http://telegram.me/VenezuelaTG                                |
-| Ubuntu                 | @C3s4r             | https://telegram.me/ubuntuve                                  |
-| VIM Venezuela          | @gusga             | https://telegram.me/vimvnzla                                  |
-| Vue.js                 | @raiiac @Tur3c0    | https://telegram.me/vueVe                                     |
-| Wagtail CMS            | @fr33co            | https://telegram.me/joinchat/AFVMlQTWq-3CcTsvGDhO-g           |
-| Wikimedia Venezuela    | @KDels             | https://telegram.me/grupowmve                                 |
-| Women in Tech          | @m0000g - @tatadbb | https://telegram.me/womenintech_spanish                       |
-| Wordpress Venezuela    | @Richzendy - @skatox - @ThePhoenixBird | https://telegram.me/WordPressVE           |
-| Yii Venezuela          | @oteroweb  - @skatox - @raiiac | https://telegram.me/YiiVzla                       |
-| XANADU GNU/linux       | @sinfallas         | https://telegram.me/xanadulinux                               |
+| Comunidad                                | Administrador                            | Link                                     |
+| ---------------------------------------- | ---------------------------------------- | ---------------------------------------- |
+| Android                                  | ...                                      | https://telegram.me/AndroidDevVzla       |
+| Android (Soporte Técnico)                | @cyberthrone                             | https://telegram.me/joinchat/B5A3bAaZNO-_0HkAavsO1w |
+| Angular                                  | @abr4xas - @Villanuevand - @jmespiz - @jobsamuel - @skatox | https://telegram.me/ngvenezuela          |
+| ArchLinux y Derivados                    | @goidor                                  | https://telegram.me/archlinuxVE          |
+| Bases de Datos                           | @jelitox                                 | https://telegram.me/bdvzla               |
+| Bash/Zsh.Ve                              | @Tur3c0                                  | https://telegram.me/BashVe               |
+| Bitcoin                                  | @ajsb85                                  | https://telegram.me/btcven               |
+| C++                                      | @Kalpar501                               | https://telegram.me/joinchat/BrCK8gmzgY_A2-Z2qg_MRg |
+| Conocimiento Libre                       | @Seraph1                                 | https://telegram.me/joinchat/B9JUAATRuqeYAxaGYLq-ng |
+| CSL_VE                                   | @phenobarbital                           | https://telegram.me/joinchat/CIpccAYQwKfi_kktTuKisw |
+| Data Science Venezuela                   | @map0logo                                | https://telegram.me/DataScienceVE        |
+| Datos Abiertos y scraping                | @seraph1                                 | https://telegram.me/joinchat/B9JUAAaks9m5-2TefJsAuw |
+| Desarrollo VideoJuegos                   | @alexr1712                               | https://telegram.me/joinchat/B_QIWkDGwHp87P8N02KxlA |
+| Django                                   | @ebar0n                                  | https://telegram.me/joinchat/BJxZXQGEslbc0kdty8hRbQ |
+| Docker                                   | @Seraph1                                 | https://telegram.me/joinchat/B9JUAD5FWUGUQveQWCPZ6w |
+| Electrónica                              | @oteroweb                                | https://telegram.me/ElectroVe            |
+| Elixir                                   | @gusga - @highercomve                    | https://telegram.me/ElixirVe             |
+| FreeCodeCamp Barquisimeto                | @mirabalj                                | https://telegram.me/joinchat/AFn8xT7vPnlQbJc9mScY_A |
+| Freelancers Venezuela                    | @alexr1712 @oteroweb                     | https://telegram.me/freelancersve        |
+| Git                                      | @johannnn @Tur3c0                        | https://telegram.me/git_ve               |
+| Go                                       | @aasanchez                               | https://telegram.me/golangve             |
+| Front-End HTML-CSS.ve                    | @Tur3c0                                  | https://telegram.me/HTML_CSS_Ve          |
+| iOS                                      | @ajmarquez                               | https://telegram.me/joinchat/AH2ZUgIUXVcougUIOTurtg |
+| IoT, SoC, Arduino, Raspberry Pi, Orange Pi | @mirabalj                                | http://bit.ly/iot_latam                  |
+| Interaction Design                       | @m0000g                                  | https://telegram.me/interactiondesgin_spanish |
+| Intercambio Idiomas                      | @oteroweb                                | https://telegram.me/joinchat/BSBThz9-rGFHFQqukOoGww |
+| JavaScript Venezuela                     | @ajsb85                                  | https://telegram.me/vzlajs               |
+| Joomla                                   | @oteroweb                                | https://telegram.me/joinchat/BSBThwEBgP3723Tmij0lnw |
+| Juegos                                   | @edgardoweb                              | https://telegram.me/joinchat/AGqisAA-jlmIAAihME16vg |
+| Laravel Venezuela                        | @racosta26, @oteroweb                    | https://telegram.me/laravelVe            |
+| LibreOffice Venezuela                    | @Tur3c0 @Cyberthrone @Naudy              | https://telegram.me/LibreOfficeVe        |
+| Libros Técnicos                          | @willicab                                | https://telegram.me/LibrosTecnicos       |
+| Libros (PacktPub)                        | @guerrerocarlos                          | https://telegram.me/packtpubfreelearning |
+| Linux Venezuela                          | @andres_code                             | https://telegram.me/linux_ve             |
+| Matemáticas                              | @KDels                                   | https://telegram.me/canalMatematicas     |
+| Mobile Híbrido                           | ...                                      | https://telegram.me/mobilehybridappsve   |
+| MongoDB Venezuela                        | @ch1nux                                  | https://telegram.me/joinchat/02fb5338009af29975c7d694d2aec965 |
+| Mozilla                                  | @ajsb85                                  | https://telegram.me/mozilla_venezuela    |
+| Nginx Venezuela                          | @alexr1712                               | https://telegram.me/nginxvzla            |
+| Odoo Venezuela Devs                      | @fr33co                                  | https://telegram.me/OdooVeDevs           |
+| Ofertas de Empleo                        | @raiiac                                  | https://telegram.me/trabajovenezuela     |
+| Pentaho                                  | @hellfish2 - @Tur3c0                     | https://telegram.me/pentahoVE            |
+| PHP Venezuela                            | @Tur3c0 @aasanchez @joseayram @oyepez    | https://telegram.me/PHP_Ve               |
+| Plone Venezuela                          | @macagua                                 | https://telegram.me/PloneVe              |
+| Programadores Venezuela                  | @DitoScripts                             | https://telegram.me/ProgramadoresVenezuela |
+| Python Venezuela                         | @nhomar - @macagua                       | https://telegram.me/python_venezuela     |
+| RadioGNU                                 | ...                                      | https://telegram.me/radiognu             |
+| Radiotransmisores                        | @Carlosjq10                              | https://telegram.me/joinchat/EcfNBkAiETMBh62FdGrxRw |
+| Redes de datos y servidores              | @jotagarbar                              | https://telegram.me/joinchat/B4dJbwa1g_BBBGcEQNxDMw |
+| Ruby                                     | @andres_code - @highercomve - @hipsss    | https://telegram.me/ruby_ve              |
+| SEO                                      | @oteroweb                                | https://telegram.me/joinchat/BSBThwXSgx0-XiGZL6P6fQ |
+| ST.ve                                    | @Tur3c0                                  | https://telegram.me/st3_ve               |
+| Symfony                                  |                                          | https://telegram.me/symfonyVe            |
+| SysAdminVE                               | @arawako                                 | https://telegram.me/SysAdminVE           |
+| Tabletas Canaima                         | @edgardoweb                              | https://telegram.me/joinchat/AGqisAI0UHkuBQDbuWm34g |
+| Telegram Venezuela                       | @tomivs @vicxyz                          | http://telegram.me/VenezuelaTG           |
+| Ubuntu                                   | @C3s4r                                   | https://telegram.me/ubuntuve             |
+| VIM Venezuela                            | @gusga                                   | https://telegram.me/vimvnzla             |
+| Vue.js                                   | @raiiac @Tur3c0                          | https://telegram.me/vueVe                |
+| Wagtail CMS                              | @fr33co                                  | https://telegram.me/joinchat/AFVMlQTWq-3CcTsvGDhO-g |
+| Wikimedia Venezuela                      | @KDels                                   | https://telegram.me/grupowmve            |
+| Women in Tech                            | @m0000g - @tatadbb                       | https://telegram.me/womenintech_spanish  |
+| Wordpress Venezuela                      | @Richzendy - @skatox - @ThePhoenixBird   | https://telegram.me/WordPressVE          |
+| Yii Venezuela                            | @oteroweb  - @skatox - @raiiac           | https://telegram.me/YiiVzla              |
+| XANADU GNU/linux                         | @sinfallas                               | https://telegram.me/xanadulinux          |
 
 
 ## Licencia

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | CSL_VE                 | @phenobarbital     | https://telegram.me/joinchat/CIpccAYQwKfi_kktTuKisw           |
 | Data Science Venezuela | @map0logo          | https://telegram.me/DataScienceVE                             |
 | Datos Abiertos y scraping | @seraph1        | https://telegram.me/joinchat/B9JUAAaks9m5-2TefJsAuw           |
-| Desarrollo VideoJuegos | @alexr1712         | https://telegram.me/joinchat/B_QIWkDGwHp87P8N02KxlA           |
+| Desarrollo VideoJuegos | @alexr1712         | https://telegram.me/devjuegos                                 |
 | Django                 | @ebar0n            | https://telegram.me/joinchat/BJxZXQGEslbc0kdty8hRbQ           |
 | Docker                 | @Seraph1           | https://telegram.me/joinchat/B9JUAD5FWUGUQveQWCPZ6w           |
 | Electrónica            | @oteroweb          | https://telegram.me/ElectroVe                                 |


### PR DESCRIPTION
Se ha actualizado el link del grupo de desarrollo de video juegos con un alias publico.