### PR TITLE
Se corrige enlace de la Comunidad Wikimedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Si deseas agregar algun canal o tienes alguna sugerencia, puedes usar [@openve](
 * [Ubuntu](https://t.me/ubuntuve) - @C3s4r
 * [VIM Venezuela](https://t.me/vimvnzla) - @gusga
 * [WebAssembly.ve](https://t.me/webassemblyve) - @seraph9
-* [Wikimedia Venezuela](https://t.me/wikimediave) - @oscar_costero
+* [Wikimedia Venezuela](https://t.me/wikimedia_ve) - @oscar_costero
 * [Women in Tech](https://t.me/womenintech_spanish) - @m0000g - @tatadbb
 * [Wordpress Venezuela](https://t.me/WordPressVE) - @Richzendy - @skatox - @ThePhoenixBird
 * [XANADU GNU/linux](https://t.me/xanadulinux) - @sinfallas


### PR DESCRIPTION
Existe un canal de Wikimedia, pero aún no tengo la info de quien lo administra. Cuando tenga la información lo agrego en un nuevo PR. El actual enlace al grupo apuntaba al canal.