### PR TITLE
Añadidos grupos de WordPress, Odoo y Scrum

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Si deseas agregar algún canal o tienes alguna sugerencia, puedes usar [@openve]
 * [Nginx Venezuela](https://t.me/nginxvzla) - @alexr1712
 * [NoSQL Venezuela](https://t.me/NoSQLVenezuela) - @ch1nux
 * [nopCommerce CMS](https://t.me/nopCommerceVe) - @javiermadridc - @jamc92
+* [Odoo Venezuela](https://t.me/OdooVenezuela) - @odoo_venezuela - @guillermm - @Setroot
 * [Odoo Venezuela Devs](https://t.me/OdooVeDevs) - @fr33co
 * [OpenStreetMaps Venezuela](https://t.me/OSMve) - @algarinr - @delldor - @sebasmagri
 * [Pentaho](https://t.me/pentahoVE) - @hellfish2 - @Tur3c0
@@ -83,6 +84,7 @@ Si deseas agregar algún canal o tienes alguna sugerencia, puedes usar [@openve]
 * [Ruby](https://t.me/ruby_ve) - @andres_code - @highercomve - @hipsss
 * [Rust Venezuela](https://t.me/rustlangVE) - @Armiixteryx
 * [Security VE](https://t.me/itsec_ve) - @coffeenights
+* [Scrum Master Venezuela](https://t.me/scrumvenezuela) - @monicatahan - @ProfeSysAdmin
 * [SEO](https://t.me/joinchat/AAAAAD4XBh3KdvGZgVoM2A) - @oteroweb
 * [Sistemas Distribuidos](https://t.me/sistemas_distribuidos_ve) - @gusga
 * [ST.ve](https://t.me/st3_ve) - @Tur3c0
@@ -95,7 +97,10 @@ Si deseas agregar algún canal o tienes alguna sugerencia, puedes usar [@openve]
 * [WebAssembly.ve](https://t.me/webassemblyve) - @seraph9
 * [Wikimedia Venezuela](https://t.me/wikimedia_ve) - @oscar_costero
 * [Women in Tech](https://t.me/womenintech_spanish) - @m0000g - @tatadbb
-* [Wordpress Venezuela](https://t.me/WordPressVE) - @Richzendy - @skatox - @ThePhoenixBird
+* [WordPress Anzoátegui](https://t.me/WPAnzoategui) - @AnnaCD - @darrycastro
+* [WordPress Guarenas-Guatire](https://t.me/WPGuarenasGuatire) - @BragnielJimenez - @pedrourbina - @YordanSoares
+* [WordPress Venezuela](https://t.me/WPVenezuela) - @Richzendy - @skatox - @ThePhoenixBird
+* [WordPress Venezuela | Traducciones](https://t.me/WPVenezuela_l10n) - @Jordicuevas - @YordanSoares
 * [XANADU GNU/linux](https://t.me/xanadulinux) - @sinfallas
 * [Yii Venezuela](https://t.me/YiiVzla) - @oteroweb  - @skatox - @raiiac
 * [Lightning Network en Español](https://t.me/lightning_network_spanish) - @negrunch - @Jochemin - @sntgvrg


### PR DESCRIPTION
**Grupos añadidos:**
- Odoo Venezuela
- Scrum Master Venezuela
- WordPress Anzoátegui
- WordPress Guarenas-Guatire
- WordPress Venezuela | Traducciones

**Correcciones:**
- Pequeña corrección en la «P» de WordPress en el grupo «WordPress Venezuela» y actualizado el enlace del canal.